### PR TITLE
improve CLI arguments & add plaintext

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Usage: substreams-sink run [options]
 Substreams Sink
 
 Options:
+  -v, --version                        version for substreams-sink
   -e --substreams-endpoint <string>    Substreams gRPC endpoint to stream data from (env: SUBSTREAMS_ENDPOINT)
   --manifest <string>                  URL of Substreams package (env: MANIFEST)
   --module-name <string>               Name of the output module (declared in the manifest) (env: MODULE_NAME)
@@ -52,15 +53,16 @@ Options:
   --substreams-api-key <string>        API key for the Substream endpoint (env: SUBSTREAMS_API_KEY)
   --delay-before-start <int>           Delay (ms) before starting Substreams (default: 0, env: DELAY_BEFORE_START)
   --cursor <string>                    Cursor to stream from. Leave blank for no cursor
-  --production-mode <boolean>          Enable production mode, allows cached Substreams data if available (default: "false", env: PRODUCTION_MODE)
+  --production-mode <boolean>          Enable production mode, allows cached Substreams data if available (choices: "true", "false", default: false, env: PRODUCTION_MODE)
+  --final-blocks-only <boolean>        Only process blocks that have pass finality, to prevent any reorg and undo signal by staying further away from the chain HEAD (choices: "true", "false", default: false, env: FINAL_BLOCKS_ONLY)
   --inactivity-seconds <int>           If set, the sink will stop when inactive for over a certain amount of seconds (default: 300, env: INACTIVITY_SECONDS)
+  --headers [string...]                Set headers that will be sent on every requests (ex: --headers X-HEADER=headerA) (default: {}, env: HEADERS)
+  --plaintext <boolean>                Establish GRPC connection in plaintext (choices: "true", "false", default: false, env: PLAIN_TEXT)
+  --verbose <boolean>                  Enable verbose logging (choices: "true", "false", default: false, env: VERBOSE)
   --hostname <string>                  The process will listen on this hostname for any HTTP and Prometheus metrics requests (default: "localhost", env: HOSTNAME)
   --port <int>                         The process will listen on this port for any HTTP and Prometheus metrics requests (default: 9102, env: PORT)
   --metrics-labels [string...]         To apply generic labels to all default metrics (ex: --labels foo=bar) (default: {}, env: METRICS_LABELS)
-  --collect-default-metrics <boolean>  Collect default metrics (default: "false", env: COLLECT_DEFAULT_METRICS)
-  --headers [string...]                Set headers that will be sent on every requests (ex: --headers X-HEADER=headerA) (default: {}, env: HEADERS)
-  --final-blocks-only <boolean>        Only process blocks that have pass finality, to prevent any reorg and undo signal by staying further away from the chain HEAD (default: "false", env: FINAL_BLOCKS_ONLY)
-  --verbose <boolean>                  Enable verbose logging (default: "false", env: VERBOSE)
+  --collect-default-metrics <boolean>  Collect default metrics (choices: "true", "false", default: false, env: COLLECT_DEFAULT_METRICS)
   -h, --help                           display help for command
 ```
 
@@ -84,12 +86,22 @@ STOP_BLOCK=1000020
 
 **example.js**
 ```js
-import pkg from "./package.json" assert { type: "json" };
 import { commander, setup, prometheus, http, logger, fileCursor } from "substreams-sink";
+
+const pkg = {
+  name: "substreams-sink",
+  version: "0.0.1",
+  description: "Substreams Sink long description",
+}
 
 // Setup CLI using Commander
 const program = commander.program(pkg);
-const command = commander.run(program, pkg);
+const command = commander.addRunOptions(program);
+logger.setName(pkg.name);
+
+// Setup CLI using Commander
+const program = commander.program(pkg);
+const command = commander.addRunOptions(program);
 logger.setName(pkg.name);
 
 // Custom Prometheus Counters

--- a/example.js
+++ b/example.js
@@ -1,9 +1,14 @@
-import pkg from "./package.json" assert { type: "json" };
 import { commander, setup, prometheus, http, logger, fileCursor } from "./dist/index.js";
+
+const pkg = {
+  name: "substreams-sink",
+  version: "0.0.1",
+  description: "Substreams Sink long description",
+}
 
 // Setup CLI using Commander
 const program = commander.program(pkg);
-const command = commander.run(program, pkg);
+const command = commander.addRunOptions(program);
 logger.setName(pkg.name);
 
 // Custom Prometheus Counters

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "substreams-sink",
-    "version": "0.15.2",
+    "version": "0.16.0",
     "description": "Substreams Sink",
     "type": "module",
     "exports": "./dist/index.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,13 +2,9 @@
 export const DEFAULT_HOSTNAME = "localhost";
 export const DEFAULT_PORT = 9102;
 export const DEFAULT_CURSOR_PATH = "cursor.lock";
-export const DEFAULT_VERBOSE = "false";
 export const DEFAULT_INACTIVITY_SECONDS = 300;
-export const DEFAULT_PRODUCTION_MODE = "false";
 export const DEFAULT_DELAY_BEFORE_START = 0;
 export const DEFAULT_METRICS_LABELS = {};
-export const DEFAULT_COLLECT_DEFAULT_METRICS = "false";
 export const DEFAULT_START_BLOCK = "-1";
 export const DEFAULT_PARAMS = [];
 export const DEFAULT_HEADERS = new Headers();
-export const DEFAULT_FINAL_BLOCKS_ONLY = "false";

--- a/src/http.ts
+++ b/src/http.ts
@@ -14,13 +14,12 @@ export const server = http.createServer(async (req, res) => {
     }
 });
 
-export async function listen(options: RunOptions) {
+export async function listen(options: RunOptions): Promise<http.Server> {
     const hostname = options.hostname;
     const port = options.port;
     return new Promise(resolve => {
         server.listen(port, hostname, () => {
-            logger.info("prometheus server", { hostname, port });
-            resolve(true);
+            resolve(server);
         });
     })
 }

--- a/src/list.ts
+++ b/src/list.ts
@@ -1,15 +1,13 @@
 import { readPackage } from "@substreams/manifest";
 import { getModules } from "@substreams/core";
 
-import { logger } from "./logger.js";
-
 export async function list(url: string) {
     const spkg = await readPackage(url)
     const compatible = []
 
     for (const { name, output } of getModules(spkg)) {
         if (!output) continue;
-        logger.info('module', { name, output })
+        console.log('module', { name, output })
         compatible.push(name)
     }
 

--- a/src/prometheus.ts
+++ b/src/prometheus.ts
@@ -94,7 +94,6 @@ export function onPrometheusMetrics(emitter: BlockEmitter) {
 }
 
 export function handleSession(session: SessionInit) {
-    logger.info("session", { traceId: String(session.traceId), resolvedStartBlock: String(session.resolvedStartBlock), linearHandoffBlock: String(session.linearHandoffBlock), maxParallelWorkers: String(session.maxParallelWorkers) });
     const labelNames = ["trace_id", "resolved_start_block", "linear_handoff_block", "max_parallel_workers"];
     const gauge = registerGauge("session", "Substreams Session", labelNames) as Gauge;
     gauge.labels({
@@ -106,7 +105,6 @@ export function handleSession(session: SessionInit) {
 }
 
 export function handleManifest(emitter: BlockEmitter, moduleHash: string, options: RunOptions) {
-    logger.info("manifest", { moduleHash, manifest: options.manifest, substreamsEndpoint: options.substreamsEndpoint, finalBlocksOnly: options.finalBlocksOnly, productionMode: options.productionMode });
     const labelNames = ["module_hash", "manifest", "output_module", "substreams_endpoint", "start_block_num", "stop_block_num", "production_mode", "final_blocks_only"];
     const gauge = registerGauge("manifest", "Substreams manifest and sha256 hash of map module", labelNames) as Gauge;
     gauge.labels({

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -12,7 +12,7 @@ import { health } from "./health.js";
 
 export async function setup(options: RunOptions) {
     // Configure logging with TSLog
-    if (String(options.verbose) === "true") logger.enable();
+    if (options.verbose) logger.enable();
 
     // Download Substream package
     const manifest = options.manifest;
@@ -24,20 +24,19 @@ export async function setup(options: RunOptions) {
     const token = options.substreamsApiKey ?? options.substreamsApiToken;
     if ( token?.includes(".")) throw new Error("JWT token is not longer supported, please use Substreams API key instead");
 
-    // append https if not present
-    if (baseUrl.match(/http/) === null) {
-        baseUrl = `https://${baseUrl}`;
-    }
-
     // User parameters
-    const outputModule = options.moduleName;
     const startBlockNum = options.startBlock as any;
-    const stopBlockNum = options.stopBlock as any;
-    const params = options.params;
-    const headers = options.headers;
-    const startCursor = options.cursor;
-    const productionMode = String(options.productionMode) === "true";
-    const finalBlocksOnly = String(options.finalBlocksOnly) === "true";
+    const stopBlockNum = options.stopBlock;
+    const { moduleName: outputModule, cursor: startCursor } = options; // renamed otions
+    const { params, headers, productionMode, finalBlocksOnly, plaintext } = options;
+
+    // append https/http if not present
+    if (!baseUrl.startsWith("http")) {
+        baseUrl = `${plaintext ? "http" : "https"}://${baseUrl}`;
+    }
+    if ( plaintext && baseUrl.startsWith("https")) {
+        throw new Error("--plaintext mode is not supported with https");
+    }
 
     // Adding default headers
     headers.set("X-User-Agent", "substreams-sink");


### PR DESCRIPTION
- [x] improve logic for `boolean` CLI arguments
- [x] add `--plaintext` as CLI argument
  - [x] throw error if `https://` is used and `plaintext` is  `true`
- [x] make `pkg` optional arguments if not provided